### PR TITLE
Update Python Lesson 3 list examples

### DIFF
--- a/python/lesson3/tutorial.md
+++ b/python/lesson3/tutorial.md
@@ -73,19 +73,25 @@ for a more complete reference:
 
     >>> places_to_visit
     ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
-
+    
+    >>> places_to_visit
+    ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
     >>> places_to_visit[1] = "Peru"
     >>> places_to_visit
     ['Mexico', 'Peru', 'Kenya', 'Nepal', 'New Zealand']
 
-    >>> places_to_visit.pop()
-    'Peru'
     >>> places_to_visit
     ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
-
-    >>> places_to_visit.append("Columbia")
+    >>> places_to_visit.pop()
+    'New Zealand'
     >>> places_to_visit
-    ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand', 'Columbia']
+    ['Mexico', 'Portugal', 'Kenya', 'Nepal']
+
+    >>> places_to_visit
+    ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
+    >>> places_to_visit.append("Colombia")
+    >>> places_to_visit
+    ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand', 'Colombia']
 
 Try some of these out yourself:
 

--- a/python/lesson3/tutorial.md
+++ b/python/lesson3/tutorial.md
@@ -74,21 +74,18 @@ for a more complete reference:
     >>> places_to_visit
     ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
     
-    >>> places_to_visit
-    ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
+    >>> places_to_visit = ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
     >>> places_to_visit[1] = "Peru"
     >>> places_to_visit
     ['Mexico', 'Peru', 'Kenya', 'Nepal', 'New Zealand']
 
-    >>> places_to_visit
-    ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
+    >>> places_to_visit = ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
     >>> places_to_visit.pop()
     'New Zealand'
     >>> places_to_visit
     ['Mexico', 'Portugal', 'Kenya', 'Nepal']
 
-    >>> places_to_visit
-    ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
+    >>> places_to_visit = ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
     >>> places_to_visit.append("Colombia")
     >>> places_to_visit
     ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand', 'Colombia']


### PR DESCRIPTION
Here are some changes to the list examples in Python lesson 3 that make them a little more clear. My pair ran into some confusion with two things:

1) This example seems to be wrong:

```py
>>> places_to_visit
['Mexico', 'Peru', 'Kenya', 'Nepal', 'New Zealand']

>>> places_to_visit.pop()
'Peru'
>>> places_to_visit
['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
```

`.pop()` will pop off the last element of the list, `'New Zealand'`.

2) It seems clearer to explicitly reset the list before each example. We were a little confused about whether the examples are supposed to be one continuous REPL session or isolated examples.

(Also included a little typo fix for "Colombia" 🇨🇴 😸 🇨🇴 )